### PR TITLE
documentation ame-guide: fix typo

### DIFF
--- a/documentation/ame-guide/modules/ROOT/pages/generate/generate-aasx.adoc
+++ b/documentation/ame-guide/modules/ROOT/pages/generate/generate-aasx.adoc
@@ -1,6 +1,6 @@
 = Generate AASX/XML
 
-To generate an AASX/XML files from the Aspect Model, proceed as follows:
+To generate an AASX/XML file from the Aspect Model, proceed as follows:
 
 * Click the *Generate Document* icon. +
 A menu offers three options:


### PR DESCRIPTION
generate an AASX/XML files ==> generate an AASX/XML file (plural s removed)