### PR TITLE
Fix setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ If you want to run the aspect model editor from repositories, please ensure to c
 # enter the core directory where the package.json is located
 cd core
 
-npm install
+npm install --legacy-peer-deps
 npm run start
 ```
 


### PR DESCRIPTION
## Description
`npm install` command leads to the following errors. `--legacy-peer-deps` flag added to solve it.

```
npm error code ERESOLVE
npm error ERESOLVE could not resolve
npm error
npm error While resolving: @nx/angular@18.3.5
npm error Found: @angular-devkit/build-angular@18.0.6
npm error node_modules/@angular-devkit/build-angular
npm error   dev @angular-devkit/build-angular@"18.0.6" from the root project
npm error   peer @angular-devkit/build-angular@"^18.0.0" from @angular-builders/jest@18.0.0
npm error   node_modules/@angular-builders/jest
npm error     dev @angular-builders/jest@"^18.0.0" from the root project
npm error   2 more (jest-preset-angular, jest-preset-angular)
npm error
npm error Could not resolve dependency:
npm error peer @angular-devkit/build-angular@">= 15.0.0 < 18.0.0" from @nx/angular@18.3.5
npm error node_modules/@nx/angular
npm error   dev @nx/angular@"18.3.5" from the root project
npm error   @nx/angular@"18.3.5" from @nrwl/angular@18.3.5
npm error   node_modules/@nrwl/angular
npm error     @nrwl/angular@"18.3.5" from @nx/angular@18.3.5
npm error
npm error Conflicting peer dependency: @angular-devkit/build-angular@17.3.8
npm error node_modules/@angular-devkit/build-angular
npm error   peer @angular-devkit/build-angular@">= 15.0.0 < 18.0.0" from @nx/angular@18.3.5
npm error   node_modules/@nx/angular
npm error     dev @nx/angular@"18.3.5" from the root project
npm error     @nx/angular@"18.3.5" from @nrwl/angular@18.3.5
npm error     node_modules/@nrwl/angular
npm error       @nrwl/angular@"18.3.5" from @nx/angular@18.3.5
npm error
npm error Fix the upstream dependency conflict, or retry
npm error this command with --force or --legacy-peer-deps
npm error to accept an incorrect (and potentially broken) dependency resolution.
```

## Type of change

- [x] Documentation fix (non-breaking change which fixes an issue)

