### PR TITLE
Move Windows signing to Jenkins release job

### DIFF
--- a/.github/workflows/tagged_release.yml
+++ b/.github/workflows/tagged_release.yml
@@ -246,20 +246,6 @@ jobs:
           name: aspect-model-editor-v${{ env.RELEASE_VERSION }}-linux
           path: core/.electron/aspect-model-editor-v${{ env.RELEASE_VERSION }}-linux-glibc-v${{ env.GLIBC_VERSION }}.tar.gz
 
-      - name: Sign Windows Binaries
-        if: matrix.os == 'windows-latest'
-        id: windows-sign
-        uses: signpath/github-action-submit-signing-request@v2
-        with:
-          api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
-          organization-id: '46624a66-6595-48fd-85c3-64bdee7fecc9'
-          project-slug: 'dt.esmf'
-          signing-policy-slug: release-signing # or test-signing to sign with a self cert during development
-          artifact-configuration-slug: exe-in-zip
-          github-artifact-id: '${{ steps.upload-unsigned-exe.outputs.artifact-id }}'
-          wait-for-completion: true
-          output-artifact-directory: '${{ github.workspace }}/signed'
-
       # Release Linux executables
       - name: Create GitHub release (Linux)
         if: ${{ (matrix.os == 'ubuntu-latest') && (!contains( github.ref, '-rc' )) }}
@@ -302,24 +288,54 @@ jobs:
           file: core/.electron/aspect-model-editor-v${{ env.RELEASE_VERSION }}-mac.zip
           tag: v${{ env.RELEASE_VERSION }}
 
-      # Release Windows executable
-      - name: Create GitHub release (Windows)
-        if: ${{ (matrix.os == 'windows-latest') && (!contains(github.ref, '-rc')) }}
-        uses: svenstaro/upload-release-action@6b7fa9f267e90b50a19fef07b3596790bb941741 # v2.11.3
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: read
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.1
         with:
-          overwrite: true
-          prerelease: false
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: '${{ github.workspace }}/signed/aspect-model-editor-v${{ env.RELEASE_VERSION }}-win.zip'
-          tag: v${{ env.RELEASE_VERSION }}
+          fetch-depth: 0
 
-      # Release Windows pre-release
-      - name: Create GitHub pre-release (Windows)
-        if: ${{ (matrix.os == 'windows-latest') && (contains(github.ref, '-rc')) }}
-        uses: svenstaro/upload-release-action@6b7fa9f267e90b50a19fef07b3596790bb941741 # v2.11.3
-        with:
-          overwrite: true
-          prerelease: true
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: '${{ github.workspace }}/signed/aspect-model-editor-v${{ env.RELEASE_VERSION }}-win.zip'
-          tag: v${{ env.RELEASE_VERSION }}
+      # Sign Windows executable
+      - name: Get Artifact ID Windows
+        shell: bash
+        run: |
+          # Get the list of artifacts for the specified workflow run
+          response=$(curl -H "Authorization: Bearer $TOKEN" -H "Accept: application/vnd.github+json" "https://api.github.com/repos/${{ github.repository_owner }}/$(echo '${{ github.repository }}' | cut -d'/' -f2)/actions/runs/${{ github.run_id }}/artifacts")
+
+          # Filter out the ID of the artifacts
+          artifact_id_win=$(echo "$response" | jq -r '.artifacts[] | select(.name | contains("win")) | .id')
+
+          # Save the artifact ID in an environment variable
+          echo "ARTIFACT_ID_WIN=$artifact_id_win" >> $GITHUB_ENV
+        env:
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Commit Artifact url and version changes and push to pre release branch for jenkins Windows
+        shell: bash
+        run: |
+          ARTIFACT_URL_WIN="https://api.github.com/repos/eclipse-esmf/esmf-aspect-model-editor/actions/artifacts/$ARTIFACT_ID_WIN/zip"
+          BRANCH_NAME="pre_release_configuration"
+
+          echo "artifact_url_win=$ARTIFACT_URL_WIN" > parameters.txt
+          echo "version=${RELEASE_VERSION}" >> parameters.txt
+
+          git config --global user.email "github-actions@github.com"
+          git config --global user.name "github-actions"
+          git checkout -b $BRANCH_NAME
+          git add parameters.txt
+          git commit -m "Add parameters.txt with artifact_url_win and the version"
+          git push origin $BRANCH_NAME
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Trigger Jenkins Job, for signing executable
+        shell: bash
+        run: |
+          DATA='{"repository": {"url": "https://github.com/eclipse-esmf/esmf-aspect-model-editor", "html_url": "https://github.com/eclipse-esmf/esmf-aspect-model-editor", "owner": { "name": "ESMF"}}, "pusher": { "name": "GitHub Action", "email": "esmf-dev@eclipse.org"}}'
+          SHA1="$(echo -n "${DATA}" | openssl dgst -sha1 -hmac "${WEBHOOK_SECRET}" | sed 's/SHA1(stdin)= //')"
+          curl -X POST https://ci.eclipse.org/esmf/github-webhook/ -H "Content-Type: application/json" -H "X-GitHub-Event: push" -H "X-Hub-Signature: sha1=${SHA1}" -d "${DATA}"


### PR DESCRIPTION
Reworks the tagged release workflow to stop signing and publishing Windows binaries directly in the matrix build. The SignPath step and Windows upload-release steps were removed, and a new `release` job now fetches the Windows artifact ID, writes and pushes `parameters.txt` to `pre_release_configuration`, and triggers the Jenkins webhook to handle Windows signing externally.

## Description

Please include a summary of the changes and the related issue. List any dependencies that are required for this change.

Fixes #(number of issue in GitHub)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Additional notes:

Add any other notes or comments here.
