### PR TITLE
Refactor cleanUpProcesses to use 'child' instead of 'process'

### DIFF
--- a/core/electron/core.ts
+++ b/core/electron/core.ts
@@ -31,24 +31,29 @@ const processes: ChildProcess[] = [];
 /**
  * Cleans up all spawned backend processes by attempting to kill them.
  * Uses platform-specific commands if processed. kill fails.
- * Logs the outcome for each process.
+ * Logs the outcome for each child.
  *
  * @async
  * @returns {Promise<void>} Resolves when all processes are cleaned up.
  */
 export async function cleanUpProcesses(): Promise<void> {
-  for (const process of processes) {
-    if (!process) continue;
-    console.log(`Killing process: ${process.pid}...`);
-    if (!process.kill()) {
-      try {
-        await execPromise(isWin ? `taskkill /F /PID ${process.pid}` : `kill -9 ${process.pid}`);
-        console.log(`Killed process: ${process.pid}`);
-      } catch (error) {
-        console.error(`Failed to kill process ${process.pid}:`, error);
+  for (const child of processes) {
+    if (!child || !child.pid) continue;
+    console.log(`Killing process: ${child.pid}...`);
+
+    try {
+      if (isWin) {
+        await execPromise(`taskkill /F /T /PID ${child.pid}`);
+      } else {
+        child.kill('SIGKILL');
       }
+      console.log(`Successfully killed process: ${child.pid}`);
+    } catch (error) {
+      console.error(`Failed to kill process ${child.pid}:`, error);
     }
   }
+
+  processes.length = 0;
 }
 
 /**


### PR DESCRIPTION
Updated the cleanup function to use 'child' terminology and handle process killing more robustly.

Killing the whole tree also openJdk instance.

## Description

Please include a summary of the changes and the related issue. List any dependencies that are required for this change.

Fixes #(number of issue in GitHub)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Additional notes:

Add any other notes or comments here.
