### PR TITLE
Fix RDF lists on anonymous characteristics

### DIFF
--- a/core/libs/aspect-exporter/src/lib/rdf-list/rdf-list.service.spec.ts
+++ b/core/libs/aspect-exporter/src/lib/rdf-list/rdf-list.service.spec.ts
@@ -624,6 +624,31 @@ describe('RDF Helper', () => {
     service.push(sourceAspect, ...elements);
   };
 
+  describe('pushWithSubject()', () => {
+    it('should create list with custom blank node subject', () => {
+      const blankSubject = DataFactory.blankNode();
+      setPredicate(rdfModel.sammC.ValuesProperty());
+      const enumeration = new DefaultEnumeration({
+        metaModelVersion: '1',
+        name: '[Enumeration]',
+        aspectModelUrn: 'urn:samm:test:1.0.0#[Enumeration]_1',
+        isAnonymous: true,
+        values: [],
+        dataType: stringDataType,
+      });
+
+      service.pushWithSubject(enumeration, blankSubject, 'DD', 'gege');
+
+      const quads = rdfModel.store.getQuads(blankSubject, predicate, null, null);
+      expect(quads).toHaveLength(1);
+      const list = quads[0].object;
+      expect(Util.isBlankNode(list)).toBe(true);
+      expect(getRdfFirstCount(list)).toBe(2);
+      expect(getRestCount(list)).toBe(2);
+      expect(isEndingInNil(list)).toBe(true);
+    });
+  });
+
   describe('emptyList', () => {
     beforeEach(() => {
       setPredicate(rdfModel.samm.PropertiesProperty());

--- a/core/libs/aspect-exporter/src/lib/rdf-list/rdf-list.service.ts
+++ b/core/libs/aspect-exporter/src/lib/rdf-list/rdf-list.service.ts
@@ -16,7 +16,7 @@ import {simpleDataTypes} from '@ame/shared';
 import {inject, Injectable} from '@angular/core';
 import {DefaultProperty, DefaultValue, RdfModel, Samm} from '@esmf/aspect-model-loader';
 import {environment} from 'environments/environment';
-import {BlankNode, DataFactory, NamedNode, Quad, Quad_Object, Store, Triple, Util} from 'n3';
+import {BlankNode, DataFactory, NamedNode, Quad, Quad_Object, Quad_Subject, Store, Triple, Util} from 'n3';
 import {RdfNodeService} from '../rdf-node';
 import {ValueVisitor} from '../visitor/value/value-visitor';
 import {RdfListHelper} from './rdf-list-helper';
@@ -57,7 +57,11 @@ export class RdfListService implements CreateEmptyRdfList, EmptyRdfList {
   }
 
   push(source: SourceElementType, ...elements: ListElementType[]) {
-    const preparedList = this.getFilteredElements(source, elements);
+    return this.pushWithSubject(source, undefined, ...elements);
+  }
+
+  pushWithSubject(source: SourceElementType, customSubject?: Quad_Subject, ...elements: ListElementType[]) {
+    const preparedList = this.getFilteredElements(source, elements, customSubject);
     if (preparedList === null) {
       return this;
     }
@@ -73,7 +77,7 @@ export class RdfListService implements CreateEmptyRdfList, EmptyRdfList {
       return this;
     }
 
-    this.remove(source, ...elements);
+    this.removeWithSubject(source, customSubject, ...elements);
     this.recreateList(list, [...listElements.map(({node}) => node), ...elementsToBeAdded.listElements]);
     this.createPropertyList(elementsToBeAdded.overWrittenListElements, source);
     return this;
@@ -111,7 +115,11 @@ export class RdfListService implements CreateEmptyRdfList, EmptyRdfList {
   }
 
   remove(source: SourceElementType, ...elements: ListElementType[]) {
-    const preparedList = this.getFilteredElements(source, elements);
+    return this.removeWithSubject(source, undefined, ...elements);
+  }
+
+  removeWithSubject(source: SourceElementType, customSubject?: Quad_Subject, ...elements: ListElementType[]) {
+    const preparedList = this.getFilteredElements(source, elements, customSubject);
     if (preparedList === null || preparedList.created) {
       return this;
     }
@@ -250,7 +258,7 @@ export class RdfListService implements CreateEmptyRdfList, EmptyRdfList {
     return listElement;
   }
 
-  private getFilteredElements(source: SourceElementType, elements: ListElementType[]): StoreListReferences {
+  private getFilteredElements(source: SourceElementType, elements: ListElementType[], customSubject?: Quad_Subject): StoreListReferences {
     const relations = RdfListConstants.getRelations(this.samm, this.rdfModel.sammC);
     const children = relations.find(({source: sourceType}) => source instanceof sourceType).children;
     const types = children.map(child => child.type).filter(type => type);
@@ -266,7 +274,7 @@ export class RdfListService implements CreateEmptyRdfList, EmptyRdfList {
       return null;
     }
 
-    const subject = DataFactory.namedNode(source.aspectModelUrn);
+    const subject = customSubject || DataFactory.namedNode(source.aspectModelUrn);
     const predicate = this.resolvePredicate(source, filteredList[0]?.property || filteredList[0]);
     const {list, created} = this.getListOrCreateNew(subject, predicate);
 
@@ -299,7 +307,7 @@ export class RdfListService implements CreateEmptyRdfList, EmptyRdfList {
     return null;
   }
 
-  private createNewList(subject: NamedNode, predicate: NamedNode) {
+  private createNewList(subject: Quad_Subject, predicate: NamedNode) {
     const list = DataFactory.blankNode();
     this.store.removeQuads(this.store.getQuads(subject, predicate, this.samm.RdfNil(), null));
     this.store.addQuad(DataFactory.triple(subject, predicate, list));
@@ -307,7 +315,7 @@ export class RdfListService implements CreateEmptyRdfList, EmptyRdfList {
     return list;
   }
 
-  private getListOrCreateNew(subject: NamedNode, predicate: NamedNode): {list: Quad_Object; created: boolean} {
+  private getListOrCreateNew(subject: Quad_Subject, predicate: NamedNode): {list: Quad_Object; created: boolean} {
     const quad = this.store.getQuads(subject, predicate, null, null)?.[0];
     return quad && !this.samm.isRdfNill(quad.object.value)
       ? {list: quad.object, created: false}

--- a/core/libs/aspect-exporter/src/lib/rdf-list/rdf-list.types.ts
+++ b/core/libs/aspect-exporter/src/lib/rdf-list/rdf-list.types.ts
@@ -24,7 +24,7 @@ import {
   Trait,
   Unit,
 } from '@esmf/aspect-model-loader';
-import {BlankNode, NamedNode, Quad_Object} from 'n3';
+import {BlankNode, NamedNode, Quad_Object, Quad_Subject} from 'n3';
 
 export type ListElementType = any;
 export type SourceElementType = Aspect | Operation | Enumeration | StructuredValue | Entity | Unit | Event | Trait;
@@ -56,7 +56,7 @@ export interface RelationsChild {
 }
 
 export interface StoreListReferences {
-  subject: NamedNode;
+  subject: Quad_Subject;
   predicate: NamedNode;
   list: Quad_Object;
   created: boolean;

--- a/core/libs/aspect-exporter/src/lib/visitor/characteristic/characteristic-visitor.spec.ts
+++ b/core/libs/aspect-exporter/src/lib/visitor/characteristic/characteristic-visitor.spec.ts
@@ -62,6 +62,7 @@ describe('Characteristic Visitor', () => {
         CharacteristicVisitor,
         MockProvider(RdfListService, {
           push: vi.fn(),
+          pushWithSubject: vi.fn(),
           createEmpty: vi.fn(),
         }),
         MockProvider(RdfNodeService, {
@@ -224,7 +225,23 @@ describe('Characteristic Visitor', () => {
 
       service.visit(characteristic);
 
-      expect(service.rdfListService.push).toHaveBeenCalledWith(characteristic, 'a', 'b');
+      expect(service.rdfListService.pushWithSubject).toHaveBeenCalledWith(characteristic, undefined, 'a', 'b');
+    });
+
+    it('should pass customSubject when anonymous', () => {
+      const blankNode = DataFactory.blankNode();
+      const values = ['a', 'b'] as any;
+      const characteristic = new DefaultEnumeration({
+        metaModelVersion: '1',
+        aspectModelUrn: 'samm#[Enumeration]_1',
+        name: '[Enumeration]',
+        isAnonymous: true,
+        values,
+      });
+
+      service.visit(characteristic, blankNode);
+
+      expect(service.rdfListService.pushWithSubject).toHaveBeenCalledWith(characteristic, blankNode, 'a', 'b');
     });
 
     it('should set prefix for named DefaultValues in enumeration', () => {
@@ -251,7 +268,7 @@ describe('Characteristic Visitor', () => {
 
       service.visit(characteristic);
 
-      expect(service.rdfListService.push).toHaveBeenCalledWith(characteristic, namedVal, anonVal);
+      expect(service.rdfListService.pushWithSubject).toHaveBeenCalledWith(characteristic, undefined, namedVal, anonVal);
       expect(rdfModel.hasDependency).toHaveBeenCalledWith('samm#');
     });
   });
@@ -364,7 +381,7 @@ describe('Characteristic Visitor', () => {
       const quads = rdfModel.store.getQuads(DataFactory.namedNode('samm#sv1'), rdfModel.sammC.DeconstructionRuleProperty(), null, null);
       expect(quads).toHaveLength(1);
       expect(quads[0].object.value).toBe('(.*)');
-      expect(service.rdfListService.push).toHaveBeenCalledWith(characteristic, property);
+      expect(service.rdfListService.pushWithSubject).toHaveBeenCalledWith(characteristic, undefined, property);
     });
   });
 

--- a/core/libs/aspect-exporter/src/lib/visitor/characteristic/characteristic-visitor.ts
+++ b/core/libs/aspect-exporter/src/lib/visitor/characteristic/characteristic-visitor.ts
@@ -155,8 +155,8 @@ export class CharacteristicVisitor extends BaseVisitor<DefaultCharacteristic> {
     this.updateUnit(characteristic, customSubject);
   }
 
-  private updateEnumeration(characteristic: DefaultEnumeration, _customSubject?: Quad_Subject) {
-    this.rdfListService.push(characteristic, ...characteristic.values);
+  private updateEnumeration(characteristic: DefaultEnumeration, customSubject?: Quad_Subject) {
+    this.rdfListService.pushWithSubject(characteristic, customSubject, ...characteristic.values);
     for (const value of characteristic.values) {
       if (value instanceof DefaultValue) {
         if (!value.isAnonymous?.()) {
@@ -246,7 +246,7 @@ export class CharacteristicVisitor extends BaseVisitor<DefaultCharacteristic> {
     );
 
     // update elements
-    this.rdfListService.push(characteristic, ...characteristic.elements);
+    this.rdfListService.pushWithSubject(characteristic, customSubject, ...characteristic.elements);
 
     for (const element of characteristic.elements) {
       if (element instanceof DefaultProperty) {

--- a/core/libs/aspect-model-loader/src/lib/shared/rdf-model-util.ts
+++ b/core/libs/aspect-model-loader/src/lib/shared/rdf-model-util.ts
@@ -111,34 +111,77 @@ export class RdfModelUtil {
     }
   }
 
+  static isRdfList(rdfModel: RdfModel, node: Quad['object']): boolean {
+    if (!Util.isBlankNode(node)) {
+      return false;
+    }
+    return (
+      rdfModel.store.getQuads(node, DataFactory.namedNode(`${Samm.RDF_URI}#first`), null, null).length > 0 ||
+      rdfModel.store.getQuads(node, DataFactory.namedNode(`${Samm.RDF_URI}#rest`), null, null).length > 0
+    );
+  }
+
+  static resolveRdfListElements(rdfModel: RdfModel, head: Quad['object'], writer: Writer, processedQuads?: Set<Quad>): Quad['object'][] {
+    const elements: Quad['object'][] = [];
+    let current: Quad['object'] = head;
+    const nilUri = `${Samm.RDF_URI}#nil`;
+    const firstPred = DataFactory.namedNode(`${Samm.RDF_URI}#first`);
+    const restPred = DataFactory.namedNode(`${Samm.RDF_URI}#rest`);
+
+    while (current && current.value !== nilUri) {
+      const firstQuads = rdfModel.store.getQuads(current, firstPred, null, null);
+      if (firstQuads.length > 0) {
+        processedQuads?.add(firstQuads[0]);
+        const obj = firstQuads[0].object;
+        if (Util.isBlankNode(obj)) {
+          const itemBlankNodes = RdfModelUtil.resolveRecursiveBlankNodes(rdfModel, obj.value, writer, processedQuads);
+          elements.push(writer.blank(itemBlankNodes));
+        } else {
+          elements.push(obj);
+        }
+      }
+      const restQuads = rdfModel.store.getQuads(current, restPred, null, null);
+      if (restQuads.length > 0) {
+        processedQuads?.add(restQuads[0]);
+        current = restQuads[0].object;
+      } else {
+        break;
+      }
+    }
+    return elements;
+  }
+
   static resolveRecursiveBlankNodes(rdfModel: RdfModel, uri: string, writer: Writer, processedQuads?: Set<Quad>): Quad[] {
-    const quads: Quad[] = rdfModel.store.getQuads(DataFactory.blankNode(uri), null, null, null);
+    const blankNode = DataFactory.blankNode(uri);
+    if (RdfModelUtil.isRdfList(rdfModel, blankNode)) {
+      const listElements = RdfModelUtil.resolveRdfListElements(rdfModel, blankNode, writer, processedQuads);
+      return listElements.map(el => DataFactory.quad(blankNode, DataFactory.namedNode(`${Samm.RDF_URI}#first`), el));
+    }
+
+    const quads: Quad[] = rdfModel.store.getQuads(blankNode, null, null, null);
     const blankNodes = [];
 
     for (const quad of quads) {
       processedQuads?.add(quad);
-      if (Util.isBlankNode(quad.subject) && Util.isBlankNode(quad.object)) {
-        const currentBlankNodes = RdfModelUtil.resolveRecursiveBlankNodes(rdfModel, quad.object.value, writer, processedQuads);
 
-        if (currentBlankNodes.every(({predicate}) => predicate.value.startsWith(Samm.RDF_URI))) {
-          blankNodes.push(...currentBlankNodes);
-          continue;
-        }
+      if (quad.object.value === `${Samm.RDF_URI}#nil`) {
+        blankNodes.push(DataFactory.quad(quad.subject, quad.predicate, writer.list([]) as unknown as Quad['object']));
+        continue;
+      }
 
-        blankNodes.push(DataFactory.quad(quad.subject, quad.predicate, writer.blank(currentBlankNodes)));
+      if (RdfModelUtil.isRdfList(rdfModel, quad.object)) {
+        const listElements = RdfModelUtil.resolveRdfListElements(rdfModel, quad.object, writer, processedQuads);
+        blankNodes.push(DataFactory.quad(quad.subject, quad.predicate, writer.list(listElements) as unknown as Quad['object']));
         continue;
       }
 
       if (Util.isBlankNode(quad.object)) {
         const currentBlankNodes = RdfModelUtil.resolveRecursiveBlankNodes(rdfModel, quad.object.value, writer, processedQuads);
-
-        blankNodes.push(...currentBlankNodes);
+        blankNodes.push(DataFactory.quad(quad.subject, quad.predicate, writer.blank(currentBlankNodes)));
         continue;
       }
 
-      if (quad.object.value !== `${Samm.RDF_URI}#nil`) {
-        blankNodes.push(DataFactory.quad(quad.subject, quad.predicate, quad.object));
-      }
+      blankNodes.push(DataFactory.quad(quad.subject, quad.predicate, quad.object));
     }
 
     return blankNodes;

--- a/core/libs/aspect-model-loader/src/lib/shared/rdf-model.spec.ts
+++ b/core/libs/aspect-model-loader/src/lib/shared/rdf-model.spec.ts
@@ -14,6 +14,7 @@
 import {DataFactory, Store} from 'n3';
 import {describe, expect, it} from 'vitest';
 import {RdfModel} from './rdf-model';
+import {RdfModelUtil} from './rdf-model-util';
 
 describe('RdfModel', () => {
   it('should initialize with default vocabularies and prefixes', () => {
@@ -68,5 +69,36 @@ describe('RdfModel', () => {
     );
 
     expect(rdfModel.getLocale(quadWithLang)).toBe('de');
+  });
+
+  it('should resolve recursive blank nodes including RDF lists', () => {
+    const store = new Store();
+    const rdfModel = new RdfModel(store, '2.2.0');
+    const writer = {
+      list: (elements: unknown[]) => ({termType: 'List', elements}),
+      blank: (elements: unknown[]) => ({termType: 'Blank', elements}),
+    } as any;
+
+    const b0 = DataFactory.blankNode('b0');
+    const bList1 = DataFactory.blankNode('bList1');
+    const bList2 = DataFactory.blankNode('bList2');
+
+    store.addQuad(b0, rdfModel.samm.RdfType(), rdfModel.sammC.EnumerationCharacteristic());
+    store.addQuad(b0, rdfModel.sammC.ValuesProperty(), bList1);
+    store.addQuad(bList1, rdfModel.samm.RdfFirst(), DataFactory.literal('DD'));
+    store.addQuad(bList1, rdfModel.samm.RdfRest(), bList2);
+    store.addQuad(bList2, rdfModel.samm.RdfFirst(), DataFactory.literal('gege'));
+    store.addQuad(bList2, rdfModel.samm.RdfRest(), rdfModel.samm.RdfNil());
+
+    const result = RdfModelUtil.resolveRecursiveBlankNodes(rdfModel, 'b0', writer);
+    expect(result.length).toBe(2);
+
+    const typeQuad = result.find(q => q.predicate.value === rdfModel.samm.RdfType().value);
+    expect(typeQuad?.object.value).toBe(rdfModel.sammC.EnumerationCharacteristic().value);
+
+    const valuesQuad = result.find(q => q.predicate.value === rdfModel.sammC.ValuesProperty().value);
+    expect(valuesQuad).toBeDefined();
+    expect((valuesQuad?.object as any).termType).toBe('List');
+    expect((valuesQuad?.object as any).elements.length).toBe(2);
   });
 });

--- a/core/libs/rdf/src/lib/services/rdf-serializer.service.spec.ts
+++ b/core/libs/rdf/src/lib/services/rdf-serializer.service.spec.ts
@@ -328,4 +328,43 @@ describe('RdfSerializerService', () => {
     expect(serialized).not.toContain('samm:operations []');
     expect(serialized).not.toContain('samm:events []');
   });
+
+  it('should serialize anonymous inline enumeration characteristic with values list correctly', () => {
+    const store = new Store();
+    const rdfModel = new RdfModel(store, '2.2.0', 'urn:samm:com.examples:1.0.0');
+    const blankChar = DataFactory.blankNode('b_char');
+    const listHead = DataFactory.blankNode('b_list1');
+    const listSecond = DataFactory.blankNode('b_list2');
+
+    store.addQuad(
+      DataFactory.quad(DataFactory.namedNode('urn:samm:com.examples:1.0.0#property1'), rdfModel.samm.RdfType(), rdfModel.samm.Property()),
+    );
+    store.addQuad(
+      DataFactory.quad(DataFactory.namedNode('urn:samm:com.examples:1.0.0#property1'), rdfModel.samm.CharacteristicProperty(), blankChar),
+    );
+    store.addQuad(DataFactory.quad(blankChar, rdfModel.samm.RdfType(), rdfModel.sammC.EnumerationCharacteristic()));
+    store.addQuad(
+      DataFactory.quad(
+        blankChar,
+        DataFactory.namedNode('urn:samm:org.eclipse.esmf.samm:meta-model:2.2.0#dataType'),
+        DataFactory.namedNode(`${Samm.XSD_URI}#string`),
+      ),
+    );
+    store.addQuad(DataFactory.quad(blankChar, rdfModel.sammC.ValuesProperty(), listHead));
+    store.addQuad(DataFactory.quad(listHead, rdfModel.samm.RdfFirst(), DataFactory.literal('DD')));
+    store.addQuad(DataFactory.quad(listHead, rdfModel.samm.RdfRest(), listSecond));
+    store.addQuad(DataFactory.quad(listSecond, rdfModel.samm.RdfFirst(), DataFactory.literal('gege')));
+    store.addQuad(DataFactory.quad(listSecond, rdfModel.samm.RdfRest(), rdfModel.samm.RdfNil()));
+
+    const serialized = service.serializeModel(rdfModel);
+    expect(serialized).toContain(':property1 a samm:Property;');
+    expect(serialized).toContain('samm:characteristic [');
+    expect(serialized).toContain('a samm-c:Enumeration;');
+    expect(serialized).toContain('samm:dataType xsd:string;');
+    expect(serialized).toContain('samm-c:values ("DD" "gege")');
+    expect(serialized).not.toContain('_:b_char');
+    expect(serialized).not.toContain('_:b_list1');
+    expect(serialized).not.toContain('first');
+    expect(serialized).not.toContain('rest');
+  });
 });


### PR DESCRIPTION
Allow RDF list operations to use a custom subject so anonymous characteristics can keep their blank-node identity. Extend recursive blank-node resolution and serializer coverage to handle inline RDF lists, and update visitor/list handling accordingly.

## Description

Please include a summary of the changes and the related issue. List any dependencies that are required for this change.

Fixes #(number of issue in GitHub)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Additional notes:

Add any other notes or comments here.
