### PR TITLE
Polish themed search and toolbar actions

### DIFF
--- a/core/apps/ame/src/assets/styles/colors.scss
+++ b/core/apps/ame/src/assets/styles/colors.scss
@@ -36,6 +36,8 @@ html {
   --ame-surface-selected: #ebebeb;
   --ame-border-color: #cfd0d1;
   --ame-border-light: #efeff0;
+  --ame-link: #005691;
+  --ame-link-hover: #00365c;
 
   // AME color palette
   // blue
@@ -127,6 +129,8 @@ html.dark-theme,
   --ame-shadow--black-25: rgba(0, 0, 0, 0.5);
   --ame-shadow--black-45: rgba(0, 0, 0, 0.7);
   --ame-top-border: #27272a;
+  --ame-link: #72b4ff;
+  --ame-link-hover: #a1cdff;
 }
 
 $characteristic-color: var(--ame-characteristic);

--- a/core/apps/ame/src/styles.scss
+++ b/core/apps/ame/src/styles.scss
@@ -43,6 +43,14 @@ body {
   color: var(--ame-font, #000000);
 }
 
+a {
+  color: var(--ame-link, #005691);
+
+  &:hover {
+    color: var(--ame-link-hover, #00365c);
+  }
+}
+
 h3 {
   font-weight: 400;
 }
@@ -295,4 +303,15 @@ mat-icon {
 
 .search-autocomplete {
   box-shadow: 0 24px 24px 0 var(--ame-shadow--black-45) !important;
+  background-color: var(--ame-surface, white);
+  color: var(--ame-font, inherit);
+
+  .mat-mdc-option {
+    color: var(--ame-font, inherit);
+
+    &:hover:not(.mdc-list-item--disabled),
+    &.mat-mdc-option-active {
+      background-color: var(--ame-surface-hover, #f3f3f3);
+    }
+  }
 }

--- a/core/libs/editor/src/lib/editor-toolbar/editor-toolbar.component.html
+++ b/core/libs/editor/src/lib/editor-toolbar/editor-toolbar.component.html
@@ -28,7 +28,7 @@
         [matTooltipHideDelay]="0"
         [disabled]="isModelEmpty() || selectedCells()?.length !== 1"
         [matTooltip]="t('toolbar.editHighlightedCell')"
-        (click)="editSelectedCell()"
+        (itemClick)="editSelectedCell()"
       >
         <mat-icon class="material-symbols-outlined">jump_to_element</mat-icon>
       </ame-bar-item>
@@ -38,7 +38,7 @@
         [matTooltipHideDelay]="0"
         [disabled]="isModelEmpty() || selectedCells()?.length === 0"
         [matTooltip]="t('toolbar.delete')"
-        (click)="onDelete()"
+        (itemClick)="onDelete()"
         data-cy="tbDeleteButton"
       >
         <mat-icon class="material-icons">delete</mat-icon>
@@ -49,7 +49,7 @@
         [matTooltipHideDelay]="0"
         [disabled]="isModelEmpty() || selectedCells()?.length !== 2"
         [matTooltip]="t('toolbar.connect')"
-        (click)="onConnect()"
+        (itemClick)="onConnect()"
         data-cy="tbConnectButton"
       >
         <mat-icon class="material-icons">commit</mat-icon>
@@ -61,7 +61,7 @@
           [matTooltipHideDelay]="0"
           [disabled]="isModelEmpty()"
           [matTooltip]="t('toolbar.collapseAll')"
-          (click)="onToggleExpand()"
+          (itemClick)="onToggleExpand()"
           data-cy="collapseExpandToggle"
         >
           <mat-icon class="material-icons rotate-45">unfold_less</mat-icon>
@@ -72,7 +72,7 @@
           [matTooltipHideDelay]="0"
           [disabled]="isModelEmpty()"
           [matTooltip]="t('toolbar.expandAll')"
-          (click)="onToggleExpand()"
+          (itemClick)="onToggleExpand()"
           data-cy="collapseExpandToggle"
         >
           <mat-icon class="material-icons rotate-45 editor-icon-active">unfold_more</mat-icon>
@@ -84,7 +84,7 @@
         [matTooltipHideDelay]="0"
         [disabled]="isModelEmpty()"
         [matTooltip]="t('toolbar.format')"
-        (click)="onFormat()"
+        (itemClick)="onFormat()"
         data-cy="formatButton"
       >
         <mat-icon class="material-icons rotate-90">schema</mat-icon>
@@ -95,7 +95,7 @@
         [matTooltipHideDelay]="0"
         [disabled]="isModelEmpty()"
         [matTooltip]="t('toolbar.validate')"
-        (click)="validateFile()"
+        (itemClick)="validateFile()"
         data-cy="tbValidateButton"
       >
         <mat-icon class="material-icons">task</mat-icon>
@@ -103,10 +103,10 @@
     </div>
 
     <div class="menu-items__group">
-      <ame-bar-item [disabled]="isModelEmpty()" [matTooltip]="t('editorCanvas.zoomInProgress')" (click)="zoomIn()">
+      <ame-bar-item [disabled]="isModelEmpty()" [matTooltip]="t('editorCanvas.zoomInProgress')" (itemClick)="zoomIn()">
         <mat-icon>zoom_in</mat-icon>
       </ame-bar-item>
-      <ame-bar-item [disabled]="isModelEmpty()" [matTooltip]="t('editorCanvas.zoomOutProgress')" (click)="zoomOut()">
+      <ame-bar-item [disabled]="isModelEmpty()" [matTooltip]="t('editorCanvas.zoomOutProgress')" (itemClick)="zoomOut()">
         <mat-icon>zoom_out</mat-icon>
       </ame-bar-item>
     </div>

--- a/core/libs/editor/src/lib/editor-toolbar/services/file-handling.service.ts
+++ b/core/libs/editor/src/lib/editor-toolbar/services/file-handling.service.ts
@@ -530,11 +530,10 @@ export class FileHandlingService {
         }
         this.notificationsService.error({
           title: this.translate.language?.notificationService?.validationErrorTitle,
-          message: this.translate.language?.notificationService?.validationErrorMessage,
+          message: error?.error?.error?.message,
           timeout: 5000,
         });
-        console.error(`Error occurred while validating the current model (${JSON.stringify(error)})`);
-        return throwError(() => 'Validation completed with errors');
+        return throwError(() => error);
       }),
       finalize(() => localStorage.removeItem('validating')),
     );

--- a/core/libs/editor/src/lib/editor.service.ts
+++ b/core/libs/editor/src/lib/editor.service.ts
@@ -417,7 +417,7 @@ export class EditorService {
       })
       .afterOpened()
       .subscribe(() => {
-        this.maxgraphAttributeService.graph.getPlugin<FitPlugin>('FitPlugin').fit();
+        this.maxgraphAttributeService.graph.getPlugin<FitPlugin>('fit')?.fit();
         this.loadingScreenService.close();
       });
   }
@@ -430,7 +430,7 @@ export class EditorService {
       })
       .afterOpened()
       .subscribe(() => {
-        this.maxgraphAttributeService.graph.zoomActual();
+        this.maxgraphAttributeService.graph.zoomTo(1, true);
         this.loadingScreenService.close();
       });
   }

--- a/core/libs/editor/src/lib/open-element-window/open-element-window.component.spec.ts
+++ b/core/libs/editor/src/lib/open-element-window/open-element-window.component.spec.ts
@@ -13,9 +13,8 @@
 
 import {ModelApiService} from '@ame/api';
 import {ElectronSignalsService, NotificationsService} from '@ame/shared';
-import {DialogRef} from '@angular/cdk/dialog';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {MAT_DIALOG_DATA} from '@angular/material/dialog';
+import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
 import {RdfModel} from '@esmf/aspect-model-loader';
 import {TranslocoTestingModule} from '@jsverse/transloco';
 import {NamedNode, Quad, Store} from 'n3';
@@ -32,7 +31,7 @@ describe('OpenElementWindowComponent', () => {
   let modelLoaderService: ModelLoaderService;
   let electronSignalsService: ElectronSignalsService;
   let notificationService: NotificationsService;
-  let dialogRef: DialogRef<OpenElementWindowComponent>;
+  let dialogRef: MatDialogRef<OpenElementWindowComponent>;
 
   const urn = 'urn:samm:com.test:1.0.0#TestElement';
   const file = 'test.ttl';
@@ -40,7 +39,7 @@ describe('OpenElementWindowComponent', () => {
   beforeEach(async () => {
     dialogRef = {
       close: vi.fn(),
-    } as unknown as DialogRef<OpenElementWindowComponent>;
+    } as unknown as MatDialogRef<OpenElementWindowComponent>;
 
     await TestBed.configureTestingModule({
       imports: [
@@ -48,7 +47,7 @@ describe('OpenElementWindowComponent', () => {
         TranslocoTestingModule.forRoot({langs: {en: {}}, translocoConfig: {availableLangs: ['en'], defaultLang: 'en'}}),
       ],
       providers: [
-        {provide: DialogRef, useValue: dialogRef},
+        {provide: MatDialogRef, useValue: dialogRef},
         {provide: MAT_DIALOG_DATA, useValue: {urn, file}},
         MockProvider(ModelApiService, {
           fetchAspectMetaModel: vi.fn(() => of({content: 'model ttl content', sourceLocation: ''} as any)),

--- a/core/libs/editor/src/lib/open-element-window/open-element-window.component.ts
+++ b/core/libs/editor/src/lib/open-element-window/open-element-window.component.ts
@@ -12,9 +12,8 @@
  */
 import {ModelApiService} from '@ame/api';
 import {ElectronSignals, ElectronSignalsService, NotificationsService} from '@ame/shared';
-import {DialogRef} from '@angular/cdk/dialog';
 import {Component, inject, OnInit} from '@angular/core';
-import {MAT_DIALOG_DATA, MatDialogModule} from '@angular/material/dialog';
+import {MAT_DIALOG_DATA, MatDialogModule, MatDialogRef} from '@angular/material/dialog';
 import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
 import {TranslocoDirective} from '@jsverse/transloco';
 import {NamedNode} from 'n3';
@@ -47,7 +46,7 @@ import {ModelLoaderService} from '../model-loader.service';
 export class OpenElementWindowComponent implements OnInit {
   private electronSignalsService: ElectronSignals = inject(ElectronSignalsService);
   private modelLoaderService = inject(ModelLoaderService);
-  private dialogRef = inject(DialogRef<OpenElementWindowComponent>);
+  private dialogRef = inject(MatDialogRef<OpenElementWindowComponent>);
   private modelApiService = inject(ModelApiService);
   private notificationService = inject(NotificationsService);
   private elementInfo = inject<{urn: string; file: string}>(MAT_DIALOG_DATA);

--- a/core/libs/shared/src/lib/components/bar-item/bar-item.component.scss
+++ b/core/libs/shared/src/lib/components/bar-item/bar-item.component.scss
@@ -22,13 +22,13 @@ $selectedColor: var(--ame-surface-hover, #f3f3f3);
   width: 55px;
   height: 50px;
 
-  &:hover {
+  &:not(.disabled):hover {
     cursor: pointer;
     background-color: var(--ame-surface-hover, #f3f3f3);
   }
 
   &.disabled {
-    pointer-events: none;
+    cursor: not-allowed;
     opacity: 0.45;
   }
 

--- a/core/libs/shared/src/lib/components/bar-item/bar-item.component.ts
+++ b/core/libs/shared/src/lib/components/bar-item/bar-item.component.ts
@@ -11,13 +11,14 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import {Component, inject, input} from '@angular/core';
+import {Component, inject, input, output} from '@angular/core';
 import {MatRipple} from '@angular/material/core';
 
 @Component({
   host: {
     '[class.disabled]': 'disabled()',
     '(mousedown)': 'onmousedown($event)',
+    '(click)': 'onClick($event)',
   },
   selector: 'ame-bar-item',
   templateUrl: './bar-item.component.html',
@@ -27,9 +28,23 @@ import {MatRipple} from '@angular/material/core';
 export class BarItemComponent {
   readonly disabled = input(false);
 
+  readonly itemClick = output<MouseEvent>();
+
   private ripple = inject(MatRipple);
 
   onmousedown(event: MouseEvent) {
+    if (this.disabled()) {
+      return;
+    }
     this.ripple.launch(event.x, event.y);
+  }
+
+  onClick(event: MouseEvent) {
+    if (this.disabled()) {
+      event.stopPropagation();
+      event.preventDefault();
+      return;
+    }
+    this.itemClick.emit(event);
   }
 }

--- a/core/libs/sidebar/src/lib/sidebar-menu/sidebar-menu.component.html
+++ b/core/libs/sidebar/src/lib/sidebar-menu/sidebar-menu.component.html
@@ -18,7 +18,7 @@
     [matTooltipHideDelay]="0"
     [class.selected]="sidebarService.workspace.opened()"
     [matTooltip]="t('tooltips.workspace')"
-    (click)="sidebarService.workspace.toggle()"
+    (itemClick)="sidebarService.workspace.toggle()"
     matTooltipPosition="right"
     data-cy="workspaceBtn"
   >
@@ -31,7 +31,7 @@
     [matTooltipHideDelay]="0"
     [class.selected]="sidebarService.sammElements.opened()"
     [matTooltip]="t('tooltips.elements')"
-    (click)="sidebarService.sammElements.toggle()"
+    (itemClick)="sidebarService.sammElements.toggle()"
     matTooltipPosition="right"
     data-cy="elementsBtn"
   >
@@ -43,7 +43,7 @@
     [matTooltipShowDelay]="0"
     [matTooltipHideDelay]="0"
     [matTooltip]="isDarkMode ? t('tooltips.lightMode') : t('tooltips.darkMode')"
-    (click)="toggleDarkMode()"
+    (itemClick)="toggleDarkMode()"
     matTooltipPosition="right"
     data-cy="darkModeBtn"
   >
@@ -55,7 +55,7 @@
     [matTooltipShowDelay]="0"
     [matTooltipHideDelay]="0"
     [matTooltip]="t('tooltips.settings')"
-    (click)="openSettingsDialog()"
+    (itemClick)="openSettingsDialog()"
     matTooltipPosition="right"
     data-cy="settingsBtn"
   >
@@ -67,7 +67,7 @@
     [matTooltipShowDelay]="0"
     [matTooltipHideDelay]="0"
     [matTooltip]="t('tooltips.notifications')"
-    (click)="openNotificationDialog()"
+    (itemClick)="openNotificationDialog()"
     matTooltipPosition="right"
     data-cy="notificationsBtn"
   >
@@ -79,7 +79,7 @@
     [matTooltipShowDelay]="0"
     [matTooltipHideDelay]="0"
     [matTooltip]="t('tooltips.help')"
-    (click)="openHelpDialog()"
+    (itemClick)="openHelpDialog()"
     matTooltipPosition="right"
     data-cy="helpBtn"
   >

--- a/core/libs/sidebar/src/lib/workspace/workspace-empty/workspace-empty.component.scss
+++ b/core/libs/sidebar/src/lib/workspace/workspace-empty/workspace-empty.component.scss
@@ -22,6 +22,6 @@ button {
 }
 
 p {
-  color: #343434;
+  color: var(--ame-font, #343434);
   line-height: 1.35;
 }

--- a/core/libs/utils/src/lib/components/elements-search/elements-search.component.html
+++ b/core/libs/utils/src/lib/components/elements-search/elements-search.component.html
@@ -24,6 +24,7 @@
   <mat-form-field class="search">
     <mat-label>{{ t('searches.elementsLabel') }}</mat-label>
     <input
+      #searchInput
       [matAutocomplete]="auto"
       [value]="searchQuery()"
       (input)="searchQuery.set($any($event.target).value)"

--- a/core/libs/utils/src/lib/components/elements-search/elements-search.component.scss
+++ b/core/libs/utils/src/lib/components/elements-search/elements-search.component.scss
@@ -41,11 +41,11 @@ $top: 100px;
 
     .mat-mdc-form-field-focus-overlay {
       opacity: 0.04 !important;
-      background-color: white;
+      background-color: var(--ame-font, black);
     }
 
     .mdc-text-field--filled:not(.mdc-text-field--disabled) {
-      background-color: white;
+      background-color: var(--ame-surface, white);
     }
 
     .mdc-line-ripple::before {
@@ -54,6 +54,22 @@ $top: 100px;
 
     .mdc-line-ripple::after {
       content: none;
+    }
+
+    // Text, caret and label must follow the theme font color, otherwise typed
+    // text and the label are invisible against the dark surface background.
+    .mat-mdc-input-element {
+      color: var(--ame-font, inherit);
+      caret-color: var(--ame-font, inherit);
+    }
+
+    .mat-mdc-form-field-label,
+    mat-label {
+      color: var(--ame-gray-600, #787878);
+    }
+
+    mat-icon {
+      color: var(--ame-gray-600, #787878);
     }
   }
 }
@@ -84,7 +100,7 @@ $top: 100px;
 
 .open-icon {
   margin-top: 10px;
-  color: #686868;
+  color: var(--ame-gray-600, #686868);
 }
 
 .has-external-element {

--- a/core/libs/utils/src/lib/components/elements-search/elements-search.component.ts
+++ b/core/libs/utils/src/lib/components/elements-search/elements-search.component.ts
@@ -25,7 +25,7 @@ import {
   SearchService,
 } from '@ame/shared';
 import {LanguageTranslationService} from '@ame/translation';
-import {Component, computed, inject, signal} from '@angular/core';
+import {AfterViewInit, Component, computed, ElementRef, inject, signal, viewChild} from '@angular/core';
 import {toObservable} from '@angular/core/rxjs-interop';
 import {MatAutocompleteModule} from '@angular/material/autocomplete';
 import {MatFormFieldModule} from '@angular/material/form-field';
@@ -42,7 +42,7 @@ import {SearchesStateService} from '../../search-state.service';
   styleUrls: ['./elements-search.component.scss'],
   imports: [MatInputModule, MatAutocompleteModule, MatFormFieldModule, MatIconModule, ElementIconComponent, TranslocoDirective],
 })
-export class ElementsSearchComponent {
+export class ElementsSearchComponent implements AfterViewInit {
   private electronSignalsService: ElectronSignals = inject(ElectronSignalsService);
   private maxgraphService = inject(MaxGraphService);
   private shapeSettingsService = inject(ShapeSettingsService);
@@ -52,6 +52,8 @@ export class ElementsSearchComponent {
   private translate = inject(LanguageTranslationService);
 
   public loadedFiles = inject(LoadedFilesService);
+
+  private readonly searchInput = viewChild<ElementRef<HTMLInputElement>>('searchInput');
 
   public searchQuery = signal('');
   public elements = signal<NamedElement[]>([]);
@@ -75,6 +77,11 @@ export class ElementsSearchComponent {
           ?.map(cell => MaxGraphHelper.getModelElement(cell)),
       );
     });
+  }
+
+  ngAfterViewInit() {
+    // Focus the input as soon as the search overlay is opened so the user can start typing immediately.
+    this.searchInput()?.nativeElement.focus();
   }
 
   openElement(element: NamedElement) {

--- a/core/libs/utils/src/lib/components/files-search/files-search.component.html
+++ b/core/libs/utils/src/lib/components/files-search/files-search.component.html
@@ -23,7 +23,14 @@
   ></div>
   <mat-form-field class="search">
     <mat-label>{{ t('searches.files.label') }}</mat-label>
-    <input [matAutocomplete]="auto" [value]="searchQuery()" (input)="searchQuery.set($any($event.target).value)" type="text" matInput />
+    <input
+      #searchInput
+      [matAutocomplete]="auto"
+      [value]="searchQuery()"
+      (input)="searchQuery.set($any($event.target).value)"
+      type="text"
+      matInput
+    />
     <mat-icon [class.rotate]="loading()" matSuffix>{{ loading() ? 'refresh' : 'description' }}</mat-icon>
 
     <mat-autocomplete class="search-autocomplete" #auto="matAutocomplete">

--- a/core/libs/utils/src/lib/components/files-search/files-search.component.scss
+++ b/core/libs/utils/src/lib/components/files-search/files-search.component.scss
@@ -55,11 +55,11 @@ $top: 100px;
 
     .mat-mdc-form-field-focus-overlay {
       opacity: 0.04 !important;
-      background-color: white;
+      background-color: var(--ame-font, black);
     }
 
     .mdc-text-field--filled:not(.mdc-text-field--disabled) {
-      background-color: white;
+      background-color: var(--ame-surface, white);
     }
 
     .mdc-line-ripple::before {
@@ -68,6 +68,22 @@ $top: 100px;
 
     .mdc-line-ripple::after {
       content: none;
+    }
+
+    // Text, caret and label must follow the theme font color, otherwise typed
+    // text and the label are invisible against the dark surface background.
+    .mat-mdc-input-element {
+      color: var(--ame-font, inherit);
+      caret-color: var(--ame-font, inherit);
+    }
+
+    .mat-mdc-form-field-label,
+    mat-label {
+      color: var(--ame-gray-600, #787878);
+    }
+
+    mat-icon {
+      color: var(--ame-gray-600, #787878);
     }
   }
 }
@@ -79,7 +95,7 @@ $top: 100px;
   span:nth-child(2) {
     font-size: 12px;
     margin-top: 3px;
-    color: rgba($color: #000000, $alpha: 0.6);
+    color: var(--ame-gray-600, #787878);
   }
 }
 

--- a/core/libs/utils/src/lib/components/files-search/files-search.component.ts
+++ b/core/libs/utils/src/lib/components/files-search/files-search.component.ts
@@ -22,7 +22,7 @@ import {
 } from '@ame/shared';
 import {FileStatus, SidebarStateService} from '@ame/sidebar';
 import {LanguageTranslationService} from '@ame/translation';
-import {Component, inject, signal} from '@angular/core';
+import {AfterViewInit, Component, ElementRef, inject, signal, viewChild} from '@angular/core';
 import {toObservable} from '@angular/core/rxjs-interop';
 import {MatAutocompleteModule} from '@angular/material/autocomplete';
 import {MatDialog} from '@angular/material/dialog';
@@ -40,7 +40,7 @@ import {OpenFileDialogComponent} from '../open-file-dialog/open-file-dialog.comp
   styleUrls: ['./files-search.component.scss'],
   imports: [MatInputModule, MatAutocompleteModule, MatFormFieldModule, MatIconModule, TranslocoDirective],
 })
-export class FilesSearchComponent {
+export class FilesSearchComponent implements AfterViewInit {
   private electronSignalsService: ElectronSignals = inject(ElectronSignalsService);
   private searchesStateService = inject(SearchesStateService);
   private sidebarStateService = inject(SidebarStateService);
@@ -52,6 +52,8 @@ export class FilesSearchComponent {
   private searchService = inject(SearchService);
   private translate = inject(LanguageTranslationService);
   private modelChecker = inject(ModelCheckerService);
+
+  private readonly searchInput = viewChild<ElementRef<HTMLInputElement>>('searchInput');
 
   private files: {file: string; namespace: string}[] = [];
 
@@ -86,6 +88,11 @@ export class FilesSearchComponent {
           this.searchableFiles.set(this.searchService.search(value, this.files, filesSearchOption));
         }
       });
+  }
+
+  ngAfterViewInit() {
+    // Focus the input as soon as the search overlay is opened so the user can start typing immediately.
+    this.searchInput()?.nativeElement.focus();
   }
 
   openFile({file, namespace, aspectModelUrn}) {


### PR DESCRIPTION
## Description

Improve search and toolbar UX across the editor by adding theme-aware link and autocomplete colors, making file and element search inputs autofocus, and routing bar-item interactions through an explicit `itemClick` output so disabled items no longer react. The changes also tighten a few editor fixes: preserve validation error messages, use the correct dialog ref/plugin APIs, and reset zoom with `zoomTo(1, true)`.
Fixes #(number of issue in GitHub)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Additional notes:

Add any other notes or comments here.
